### PR TITLE
Add display_name validation

### DIFF
--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -71,7 +71,7 @@ class PluginManifest(BaseModel):
 
     display_name: str = Field(
         "",
-        description="The display name for the extension used in the Marketplace.",
+        description="User-facing text to display as the name of this plugin",
         # Must be 3-40 characters long, containing printable word characters,
         # and must not begin or end with an underscore, white space, or
         # non-word character.
@@ -101,19 +101,12 @@ class PluginManifest(BaseModel):
     license: Optional[SPDX] = None
 
     contributions: Optional[ContributionPoints]
-    # # this would be there only for the hub.  which is not immediately planning
-    # # to support open ended keywords
-    # keywords: List[str] = Field(
-    #     default_factory=list,
-    #     description="An array of keywords to make it easier to find the "
-    #     "extension. These are included with other extension Tags on the "
-    #     "Marketplace. This list is currently limited to 5 keywords",
-    # )
-    # the hub *is* planning on supporting categories
+
     categories: List[str] = Field(
         default_factory=list,
         description="specifically defined classifiers",
     )
+
     # in the absense of input. should be inferred from version (require using rc ...)
     # or use `classifiers = Status`
     preview: Optional[bool] = Field(

--- a/npe2/manifest/schema.py
+++ b/npe2/manifest/schema.py
@@ -68,10 +68,14 @@ class PluginManifest(BaseModel):
         None,
         description="The publisher name - can be an individual or an organization",
     )
-    # easy one... we need this.  character limit?  256 char?
+
     display_name: str = Field(
         "",
         description="The display name for the extension used in the Marketplace.",
+        # Must be 3-40 characters long, containing printable word characters,
+        # and must not begin or end with an underscore, white space, or
+        # non-word character.
+        regex=r"^[^\W_][\w -~]{1,38}[^\W_]$",
     )
     # take this from setup.cfg
     description: Optional[str] = Field(

--- a/tests/test_npe2.py
+++ b/tests/test_npe2.py
@@ -164,6 +164,45 @@ def test_valid_mutations(mutator, uses_sample_plugin):
     PluginManifest(**data)
 
 
+@pytest.mark.parametrize(
+    "display_name",
+    [
+        "Here there everywhere and more with giggles and friends",
+        "ab",
+        " abc",
+        "abc ",
+        "_abc",
+        "abc_",
+        "abc♱",
+    ],
+)
+def test_invalid_display_names(display_name, uses_sample_plugin):
+    pm = list(PluginManifest.discover())[0]
+    assert pm.manifest
+    data = json.loads(pm.manifest.json(exclude_unset=True))
+    data["display_name"] = display_name
+
+    with pytest.raises(ValidationError):
+        PluginManifest(**data)
+
+
+@pytest.mark.parametrize(
+    "display_name",
+    [
+        "Some Cell & Stru买cture Segmenter",
+        "Segment Blobs and Things with Membranes",
+        "abc",
+        "abc䜁䜂",
+    ],
+)
+def test_valid_display_names(display_name, uses_sample_plugin):
+    pm = list(PluginManifest.discover())[0]
+    assert pm.manifest
+    data = json.loads(pm.manifest.json(exclude_unset=True))
+    data["display_name"] = display_name
+    PluginManifest(**data)
+
+
 def test_writer_empty_layers():
     pm = PluginManager()
     pm.discover()

--- a/tests/test_npe2.py
+++ b/tests/test_npe2.py
@@ -177,13 +177,9 @@ def test_valid_mutations(mutator, uses_sample_plugin):
     ],
 )
 def test_invalid_display_names(display_name, uses_sample_plugin):
-    pm = list(PluginManifest.discover())[0]
-    assert pm.manifest
-    data = json.loads(pm.manifest.json(exclude_unset=True))
-    data["display_name"] = display_name
-
-    with pytest.raises(ValidationError):
-        PluginManifest(**data)
+    field = PluginManifest.__fields__["display_name"]
+    value, err = field.validate(display_name, {}, loc="display_name")
+    assert err is not None
 
 
 @pytest.mark.parametrize(
@@ -196,19 +192,13 @@ def test_invalid_display_names(display_name, uses_sample_plugin):
     ],
 )
 def test_valid_display_names(display_name, uses_sample_plugin):
-    pm = list(PluginManifest.discover())[0]
-    assert pm.manifest
-    data = json.loads(pm.manifest.json(exclude_unset=True))
-    data["display_name"] = display_name
-    PluginManifest(**data)
+    field = PluginManifest.__fields__["display_name"]
+    value, err = field.validate(display_name, {}, loc="display_name")
+    assert err is None
 
 
-def test_display_name_default_is_valid(uses_sample_plugin):
-    pm = list(PluginManifest.discover())[0]
-    assert pm.manifest
-    data = json.loads(pm.manifest.json(exclude_unset=True))
-    del data["display_name"]
-    PluginManifest(**data)
+def test_display_name_default_is_valid():
+    PluginManifest(name="", entry_point="")
 
 
 def test_writer_empty_layers():

--- a/tests/test_npe2.py
+++ b/tests/test_npe2.py
@@ -203,6 +203,14 @@ def test_valid_display_names(display_name, uses_sample_plugin):
     PluginManifest(**data)
 
 
+def test_display_name_default_is_valid(uses_sample_plugin):
+    pm = list(PluginManifest.discover())[0]
+    assert pm.manifest
+    data = json.loads(pm.manifest.json(exclude_unset=True))
+    del data["display_name"]
+    PluginManifest(**data)
+
+
 def test_writer_empty_layers():
     pm = PluginManager()
     pm.discover()


### PR DESCRIPTION
This adds validation for the display_name.

Addresses #22.

This uses a regex to limit display_name to 3-40 characters. The name beginning and end must not be whitespace or and underscore. The other characters must be "word" characters.

Play with the regex [here](https://regex101.com/r/QyanPt/1)